### PR TITLE
Add syntax highlight for elsif keyword

### DIFF
--- a/Syntaxes/Puppet.tmLanguage
+++ b/Syntaxes/Puppet.tmLanguage
@@ -191,7 +191,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(case|if|unless|else)(?!::)</string>
+			<string>\b(case|if|unless|else|elsif)(?!::)</string>
 			<key>name</key>
 			<string>keyword.control.puppet</string>
 		</dict>


### PR DESCRIPTION
Add the missing `elsif` control structure to the Puppet language definition so it is highlighted in the same way as `if` and `else` in Puppet code files. 