### PR TITLE
OS and version independent README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SublimePuppet
-==================================
+=============
 
-[Puppet](puppetlabs.com) highlighting, snippets and completion for Sublime Text 2 & 3.  Now with windows parsing support.
+[Puppet][] highlighting, snippets and completion for Sublime Text 2 & 3.  Now with windows parsing support.
 
 ### Plugin installation
 
@@ -35,16 +35,8 @@ Then download the code into place from the Git version control repository or by 
 
 
 ### Puppet installation
-Before using this plugin, you must ensure that `puppet` is installed on your system. To install `puppet`, do the following:
 
-1. Install [Ruby](http://ruby-lang.org).
-
-1. Install `puppet` by typing the following in a terminal:
-   ```
-   gem install puppet
-   ```
-
-1. If you are using `rvm` or `rbenv`, ensure that they are loaded in your shell’s correct startup file. See [here](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#shell-startup-files) for more information.
+This SublimePuppet package requires Puppet be intalled on your system in order to run syntax check commands. Follow the steps outlined in the [Puppet Labs guide to Installing Puppet](https://docs.puppetlabs.com/guides/install_puppet/pre_install.html). 
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
@@ -62,6 +54,4 @@ Please note that modifications should follow these coding guidelines:
 - Vertical whitespace helps readability, don’t be afraid to use it.
 - Please use descriptive variable names, no abbreviations unless they are very well known.
 
-[pc]: https://sublime.wbond.net/installation
-[locating-executables]: http://sublimelinter.readthedocs.org/en/latest/usage.html#how-linter-executables-are-located
-[cmd]: http://docs.sublimetext.info/en/sublime-text-3/extensibility/command_palette.html
+[Puppet]: https://puppetlabs.com/

--- a/README.md
+++ b/README.md
@@ -39,17 +39,21 @@ Then download the code into place from the Git version control repository or by 
 This SublimePuppet package requires Puppet be intalled on your system in order to run syntax check commands. Follow the steps outlined in the [Puppet Labs guide to Installing Puppet](https://docs.puppetlabs.com/guides/install_puppet/pre_install.html). 
 
 ## Contributing
+
 If you would like to contribute enhancements or fixes, please do the following:
 
-1. Fork the plugin repository.
-1. Hack on a separate topic branch created from the latest `master`.
-1. Commit and push the topic branch.
-1. Make a pull request.
+1. Fork the [SublimePuppet package Github repository](https://github.com/russCloak/SublimePuppet).
+1. Hack on a separate topic branch created from the latest `master` branch.
+1. Commit and push your topic branch to your forked remote repository.
+1. Make a pull request on Github with a 
+    1. short descriptive title.
+    1. description outlining the purpose of your changes.
 1. Be patient.  ;-)
 
 Please note that modifications should follow these coding guidelines:
 
-- Indent is 4 spaces.
+- Indent is 4 spaces. 
+- Indent using spaces only.
 - Code should pass flake8 and pep257 linters.
 - Vertical whitespace helps readability, don’t be afraid to use it.
 - Please use descriptive variable names, no abbreviations unless they are very well known.

--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@ Once you install Package Control, restart ST2 and bring up the Command Palette (
 
 #### Manual
 
-**With Git:** Clone the repository in your Sublime Text "Packages" directory:
+Sublime Puppet can be manually installed to your Sublime Text "Packages" directory. You can find and open the "Packages" directory from the Sublime Text menu at:
 
-    git clone https://github.com/SublimeLinter/SublimeLinter.git
+_Preferences_ | _Browse Packages..._
 
+Then download the code into place from the Git version control repository or by directly downloading a snapshot of the latest code: 
 
-The "Packages" directory is located at:
+**With Git:** 
 
-* OS X:
+1. Change your working directory to the Sublime Text "Packages" directory
+1. Clone the repository into your Sublime Text "Packages" directory:
 
-        ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/
+        git clone https://github.com/russCloak/SublimePuppet.git
 
-* Linux:
+**Without Git:** 
 
-        ~/.config/sublime-text-2/Packages/
+1. Download the [latest SublimePuppet source code](https://github.com/russCloak/SublimePuppet/archive/master.zip) archive.
+1. Unpack the downloaded archive to a local folder somewhere.
+1. Rename the unpacked folder `SublimePuppet-master` to the new name `SublimePuppet`.
+1. Move the `SublimePuppet` folder into your Sublime Text "Packages" directory.
 
-* Windows:
-
-        %APPDATA%/Sublime Text 2/Packages/
-
-**Without Git:** Download the latest source from [here](https://github.com/russCloak/SublimePuppet/archive/master.zip) and copy the `SublimePuppet` folder to your Sublime Text "Packages" directory.
 
 ### Puppet installation
 Before using this plugin, you must ensure that `puppet` is installed on your system. To install `puppet`, do the following:


### PR DESCRIPTION
A few improvements to the README documentation:

- Replace OS specific method to find Sublime Text 2 Packages directory with method that works in both Sublime Text 2 and Sublime Text 3 on any OS
- Link to PuppetLabs install guide for puppet rather than try to maintain a list of custom install steps that only work in some *nix based OSs
- Improve the contributing guide  