### PR TITLE
Syntax hightlight improvements for class definitions

### DIFF
--- a/Syntaxes/Puppet.tmLanguage
+++ b/Syntaxes/Puppet.tmLanguage
@@ -210,6 +210,10 @@
 			<string>#variable</string>
 		</dict>
 		<dict>
+			<key>include</key>
+			<string>#constants</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>(?i)\b(import|include)\b\s*</string>
 			<key>beginCaptures</key>

--- a/Syntaxes/Puppet.tmLanguage
+++ b/Syntaxes/Puppet.tmLanguage
@@ -53,6 +53,22 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>include</key>
+					<string>#variables</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#constants</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#strings</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#numbers</string>
+				</dict>
+				<dict>
 					<key>begin</key>
 					<string>\b(inherits)\b\s+</string>
 					<key>captures</key>


### PR DESCRIPTION
These changes improve syntax highlighting for class definitions in Puppet by highlighting:

- variables, strings, numbers and constants used in class parameter default values
- constants used in code for classes and nodes  

The following screen captures illustrate the intended results of this change. 

**Before Improvements**

![selection_018](https://cloud.githubusercontent.com/assets/452515/6034401/43481bfa-ac76-11e4-87a1-7444e853b21c.png)

**After Improvements**

![selection_017](https://cloud.githubusercontent.com/assets/452515/6034406/526b46fc-ac76-11e4-8871-ea6a752b3827.png)

