### PR TITLE
Remove include from functions

### DIFF
--- a/Syntaxes/Puppet.sublime-syntax
+++ b/Syntaxes/Puppet.sublime-syntax
@@ -99,7 +99,7 @@ contexts:
       scope: constant.other.key.puppet
     - match: '(?<={)\s*\w+\s*(?=})'
       scope: constant.other.bareword.puppet
-    - match: \b(escape|gsub|alert|crit|debug|notice|defined|emerg|err|failed|file|generate|include|info|realize|search|tag|tagged|template|warning)\b
+    - match: \b(escape|gsub|alert|crit|debug|notice|defined|emerg|err|failed|file|generate|info|realize|search|tag|tagged|template|warning)\b
       scope: support.function.puppet
   constants:
     - match: (?i)\b(false|true|running|undef|present|absent|file|directory)\b


### PR DESCRIPTION
Has it's own reserved area in `keyword.control.import.include.puppet`