### PR TITLE
Update to syntax definition to support resource names

### DIFF
--- a/Preferences/SymbolList (resource).tmPreferences
+++ b/Preferences/SymbolList (resource).tmPreferences
@@ -11,7 +11,7 @@
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
-		<string>s/^\s*(\w+)\s*{\s*['"](.*)['"]:/  \u$1["$2"]/</string>
+		<string>s/^\s*(\S+)\s*{\s*['"](.*)['"]:/  \u$1["$2"]/</string>
 	</dict>
 	<key>uuid</key>
 	<string>13DD53A2-401B-4149-82B0-001374330B40</string>

--- a/Syntaxes/Puppet.sublime-syntax
+++ b/Syntaxes/Puppet.sublime-syntax
@@ -76,7 +76,7 @@ contexts:
       captures:
         1: storage.type.puppet
         2: entity.name.section.puppet
-    - match: '^\s*(\w+)\s*{\s*([''"].+[''"])\s*:'
+    - match: '^\s*(\S+)\s*{\s*([''"].+[''"])\s*:'
       scope: meta.definition.resource.puppet
       captures:
         1: storage.type.puppet

--- a/Syntaxes/Puppet.tmLanguage
+++ b/Syntaxes/Puppet.tmLanguage
@@ -201,7 +201,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(\w+)\s*{\s*(['"].+['"]):</string>
+			<string>^\s*(\S+)\s*{\s*(['"].+['"]):</string>
 			<key>name</key>
 			<string>meta.definition.resource.puppet</string>
 		</dict>


### PR DESCRIPTION
Previously resource names like sudo::conf would not be classified
properly as source.puppet meta.definition.resource.puppet storage.type.puppet
So things like cmd-r would break. This should fix that up without
introducing anything else