### PR TITLE
Regex for meta.definition.resource.puppet updated

### DIFF
--- a/Syntaxes/Puppet.sublime-syntax
+++ b/Syntaxes/Puppet.sublime-syntax
@@ -72,7 +72,7 @@ contexts:
                 3: keyword.operator.assignment.puppet
               pop: true
             - include: parameter-default-types
-    - match: '^\s*(\w+)\s*{\s*(\$[a-zA-Z_]+)\s*:'
+    - match: '^\s*(\S+)\s*{\s*(\$[a-zA-Z_]+)\s*:'
       scope: meta.definition.resource.puppet
       captures:
         1: storage.type.puppet


### PR DESCRIPTION
This was originally fixed in [PR #25] but the second change here is
for when the resource name is a variable (and it uses a different regex)

You previously requested screenshots so here is the before:
![image](https://cloud.githubusercontent.com/assets/3605906/26038835/8cafb4e4-38d6-11e7-8d2c-493f24a6b934.png)

And then the after:
![image](https://cloud.githubusercontent.com/assets/3605906/26038833/831f2338-38d6-11e7-8fc0-afe16143d69d.png)

