### PR TITLE
Full line comments

### DIFF
--- a/Syntaxes/Puppet.sublime-syntax
+++ b/Syntaxes/Puppet.sublime-syntax
@@ -122,11 +122,11 @@ contexts:
     - match: \\.
       scope: constant.character.escape.puppet
   line_comment:
-    - match: ^((#).*$\n?)
-      scope: meta.comment.full-line.puppet
+    - match: ^\s*(((#).*$\n?))
       captures:
-        1: comment.line.number-sign.puppet
-        2: punctuation.definition.comment.puppet
+        1: meta.comment.full-line.puppet
+        2: comment.line.number-sign.puppet
+        3: punctuation.definition.comment.puppet
     - match: (#).*$\n?
       scope: comment.line.number-sign.puppet
       captures:


### PR DESCRIPTION
Previously some comments were not being tagged correctly, for instance
if the line started with a space like so:

  `  # {"node":`

The line would not properly be marked comment. This patch fixes that.

![image](https://user-images.githubusercontent.com/3605906/43615173-1036c876-967c-11e8-99e6-c4a15e56b157.png)

After:

![image](https://user-images.githubusercontent.com/3605906/43615202-315bb002-967c-11e8-88f8-17ff0c8b47af.png)
